### PR TITLE
Only compare items at iLevel >= 800

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -398,7 +398,7 @@ for bag=0, NUM_BAG_SLOTS do
       local name, link, quality, iLevel, reqLevel, class, subclass, maxStack, equipSlot, texture, vendorPrice = GetItemInfo(itemlink)
       
 
-      if equipSlot == equipFilter then
+      if equipSlot == equipFilter and iLevel >= 800 then
         trinkets[a] = '=,id=' .. itemId
 		trinketNames[a] = string.gsub(name, ' ', '') .. iLevel
 		trinketsUsed[a] = {}


### PR DESCRIPTION
Avoids comparing older trinkets and rings kept in bags for utility purposes (e.g. Kirin Tor teleport ring)